### PR TITLE
Add dockerd daemon

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -295,7 +295,12 @@
 #   Specify a custom docker command name
 #   Default is set on a per system basis in docker::params
 #
+# [*daemon_command*]
+#   Specify a custom docker command name
+#   Default is 'dockerd'
+#
 # [*daemon_subcommand*]
+#  **Deprecated** Use daemon_command
 #  Specify a subcommand/flag for running docker as daemon
 #  Default is set on a per system basis in docker::params
 #
@@ -415,6 +420,7 @@ class docker(
   $package_name                      = $docker::params::package_name,
   $service_name                      = $docker::params::service_name,
   $docker_command                    = $docker::params::docker_command,
+  $daemon_command                    = $docker::params::daemon_command,
   $daemon_subcommand                 = $docker::params::daemon_subcommand,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,11 +75,11 @@ class docker::params {
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
 
-  if $daemon_subcommand == 'undef' {
-    $daemon_command = 'dockerd'
-  } else {
+  if $daemon_subcommand {
     $daemon_command = "${docker_command} ${daemon_subcommand}"
     notify {"The 'daemon_subcommand' parameter is deprecated. As of docker 17.06, 'daemon' is no longer a valid docker subcommand":}
+  } else {
+    $daemon_command = 'dockerd'
   }
   case $::osfamily {
     'Debian' : {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,7 +60,7 @@ class docker::params {
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
-  $daemon_subcommand                 = 'daemon'
+  $daemon_subcommand                 = undef
   $storage_devs                      = undef
   $storage_vg                        = undef
   $storage_root_size                 = undef
@@ -75,6 +75,12 @@ class docker::params {
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
 
+  if $daemon_subcommand == `undef` {
+    $daemon_command = 'dockerd'
+  } else {
+    $daemon_command = "${docker_command} ${daemon_subcommand}"
+    notify {"The 'daemon_subcommand' parameter is deprecated. As of docker 17.06, 'daemon' is no longer a valid docker subcommand":}
+  }
   case $::osfamily {
     'Debian' : {
       case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class docker::params {
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true
-  $package_name_default              = 'docker-engine'
+  $package_name_default              = 'docker-ce'
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,7 @@ class docker::params {
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
 
-  if $daemon_subcommand == `undef` {
+  if $daemon_subcommand == 'undef' {
     $daemon_command = 'dockerd'
   } else {
     $daemon_command = "${docker_command} ${daemon_subcommand}"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -37,7 +37,6 @@
 #   Defaults to 'true'.
 #
 class docker::service (
-  $docker_command                    = $docker::docker_command,
   $service_name                      = $docker::service_name,
   $daemon_subcommand                 = $docker::daemon_subcommand,
   $tcp_bind                          = $docker::tcp_bind,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,7 +38,7 @@
 #
 class docker::service (
   $service_name                      = $docker::service_name,
-  $daemon_subcommand                 = $docker::daemon_subcommand,
+  $daemon_command                    = $docker::daemon_command,
   $tcp_bind                          = $docker::tcp_bind,
   $ip_forward                        = $docker::ip_forward,
   $iptables                          = $docker::iptables,

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -1,7 +1,7 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKER="/usr/bin/<%= @daemon_command %>"
 
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -3,7 +3,7 @@
 # THIS FILE IS MANAGED BY PUPPET. Changes will be overwritten.
 
 # # Customize location of Docker binary (especially for development testing).
-DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKER="/usr/bin/<%= @daemon_command %>"
 
 # # If you need Docker to use an HTTP proxy, it can also be specified here.
 <% if @proxy -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -1,7 +1,7 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKER="/usr/bin/<%= @daemon_command %>"
 
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,5 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @daemon_command %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -5,7 +5,7 @@ EnvironmentFile=-/etc/sysconfig/docker-network
 <% if @daemon_environment_files %><% @daemon_environment_files.each do |param| %>EnvironmentFile=-<%= param %>
 <% end %><% end -%>
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @daemon_command %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
- Adds support for `dockerd` daemon
- deprecates `docker daemon` command
 - displays warning when using `daemon_subcommand` parameter
- changes default package name to `docker-ce`