### PR TITLE
Install compose as image

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,8 +420,18 @@ file.
 Before using the docker_compose type make sure the docker-compose utility is installed:
 
 ```puppet
-class {'docker::compose': 
+class {'docker::compose':
   ensure => present,
+}
+```
+
+The current method of installing compose is the "install as container" method. This allows you to pull compose from a private repository if you wish, and it will automatically use your docker daemon's proxy settings if that is something you require. The default installation path for compose is `/usr/local/bin/docker-compose`, but that can be changed using `compose_path` parameter. Here's an example of installing compose from a private registry to a custom path:
+
+```puppet
+class {'docker::compose':
+  ensure => 'present',
+  compose_image => 'privateregistry.io:5000/docker/compose:1.16.1',
+  compose_path => '/usr/bin/docker-compose'
 }
 ```
 
@@ -475,10 +485,10 @@ For a swarm manager:
 docker::swarm {'cluster_manager':
   init           => true,
   advertise_addr => '192.168.1.1',
-  listen_addr    => '192.168.1.1',  
-} 
+  listen_addr    => '192.168.1.1',
+}
 ```
-In the above example we have configured a swarm manager with ```init => true``` then set the ```advertise_addr``` and ```listen_addr```. Both the ```advertise_addr``` and ```listen_addr``` are set for the cluster communications between nodes. Please note the ```advertise_addr``` and ```listen_addr``` must be set for a multihomed server. For more advance flags to configure raft snapshots etc please read the readme at the top of the ```docker::swarm``` class.  
+In the above example we have configured a swarm manager with ```init => true``` then set the ```advertise_addr``` and ```listen_addr```. Both the ```advertise_addr``` and ```listen_addr``` are set for the cluster communications between nodes. Please note the ```advertise_addr``` and ```listen_addr``` must be set for a multihomed server. For more advance flags to configure raft snapshots etc please read the readme at the top of the ```docker::swarm``` class.
 
 For a swarm worker:
 ```puppet
@@ -488,7 +498,7 @@ advertise_addr => '192.168.1.2',
 listen_addr    => '192.168.1.2,
 manager_ip     => '192.168.1.1',
 token          => 'SWMTKN-1-2lw8bnr57qsu74d6iq2q1wr2wq2i334g7425dfr3zucimvh4bl-2vwn6gysbdj605l37c61iixie'
-} 
+}
 ```
 
 In this example we have joined a node to the cluster using ```join => true```. For a worker node or second manager you need to pass a current managers ip address ```manager_ip => '192.168.1.1'```
@@ -507,18 +517,18 @@ To configure a service with Puppet code please see the following examples
 To create a service
 ```puppet
 docker::services {'redis':
-    create => true,   
+    create => true,
     service_name => 'redis',
     image => 'redis:latest',
     publish => '6379:639',
-    replicas => '5', 
+    replicas => '5',
     extra_params => ['--update-delay 1m', '--restart-window 30s']
   }
 ```
 In this example we are creating a service called `redis`, as it is a new service we have set `create => true`. The `service_name` resource is the name which Docker knows the service as. The `image` resource is the image you want to base the service off, `publish` is the ports that want exposed to the outside world for the service to be consumed, `replicas` sets the amount of tasks (containers) that you want running in the service, `extra_params` allows you to configure any of the other flags that Docker gives you when you create a service for more info see `docker service create --help`
 
 To update the service
-```puppet 
+```puppet
 docker::services {'redis_update':
   create => false,
   update => true,
@@ -534,7 +544,7 @@ docker::services {'redis_scale':
   create => false,
   scale => true,
   service_name => 'redis',
-  replicas => '10', 
+  replicas => '10',
 }
 ```
 In this example we have used the command `docker service scale` with Puppet code. We have taken our service `redis` set the `create => false` and `scale => true` When using scale you have to declare your `service_name` then the number of replicas that you want. In this example we are going to scale to `10`

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -26,7 +26,7 @@ class docker::compose(
   $compose_image = $docker::params::compose_image,
 ) inherits docker::params {
   validate_re($ensure, '^(present|absent)$')
-  validate_absolute_path($install_path)
+  validate_absolute_path($compose_path)
 
   if $ensure == 'present' {
 
@@ -38,10 +38,7 @@ class docker::compose(
     }
 
   } else {
-    file { [
-      "${install_path}/docker-compose-${version}",
-      "${install_path}/docker-compose"
-    ]:
+    file {$compose_path:
       ensure => absent,
     }
   }

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -9,16 +9,14 @@
 #   Valid values are absent present
 #   Defaults to present
 #
-# [*version*]
-#   The version of Docker Compose to install.
-#   Defaults to the value set in $docker::params::compose_version
+# [*compose_image*]
+#   The docker image to pull and execute as the docker-compose command
+#   Defaults to the value set in $docker::params::compose_iage
 #
-# [*install_path*]
-#   The path where to install Docker Compose.
-#   Defaults to the value set in $docker::params::compose_install_path
 #
-# [*proxy*]
-#   Proxy to use for downloading Docker Compose.
+# [*compose_path*]
+#   The absolute path to the compose executable
+#   Defaults to the value set in $docker::params::compose_path
 #
 class docker::compose(
   $ensure = 'present',

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -22,15 +22,15 @@
 #
 class docker::compose(
   $ensure = 'present',
-  $install_path = $docker::params::compose_install_path,
-  $compose_iamge = $docker::params::compose_image,
+  $compose_path = $docker::params::compose_path,
+  $compose_image = $docker::params::compose_image,
 ) inherits docker::params {
   validate_re($ensure, '^(present|absent)$')
   validate_absolute_path($install_path)
 
   if $ensure == 'present' {
 
-    file { $install_path:
+    file { $compose_path:
       ensure  => 'file',
       owner   => 'root',
       mode    => '0755',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class docker::params {
   $storage_pool_autoextend_threshold = undef
   $storage_pool_autoextend_percent   = undef
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
-  $compose_version                   = '1.9.0'
+  $compose_image                     = 'docker/compose:1.16.1'
   $compose_install_path              = '/usr/local/bin'
 
   if $daemon_subcommand {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,7 +73,7 @@ class docker::params {
   $storage_pool_autoextend_percent   = undef
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $compose_image                     = 'docker/compose:1.16.1'
-  $compose_install_path              = '/usr/local/bin'
+  $compose_path              = '/usr/local/bin/docker-compose'
 
   if $daemon_subcommand {
     $daemon_command = "${docker_command} ${daemon_subcommand}"

--- a/templates/run.sh.erb
+++ b/templates/run.sh.erb
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Run docker-compose in a container
+#
+# This script will attempt to mirror the host paths by using volumes for the
+# following paths:
+#   * $(pwd)
+#   * $(dirname $COMPOSE_FILE) if it's set
+#   * $HOME if it's set
+#
+# You can add additional volumes (or any docker run options) using
+# the $COMPOSE_OPTIONS environment variable.
+#
+
+
+set -e
+
+IMAGE=<%= @compose_image -%>
+
+
+# Setup options for connecting to docker host
+if [ -z "$DOCKER_HOST" ]; then
+    DOCKER_HOST="/var/run/docker.sock"
+fi
+if [ -S "$DOCKER_HOST" ]; then
+    DOCKER_ADDR="-v $DOCKER_HOST:$DOCKER_HOST -e DOCKER_HOST"
+else
+    DOCKER_ADDR="-e DOCKER_HOST -e DOCKER_TLS_VERIFY -e DOCKER_CERT_PATH"
+fi
+
+
+# Setup volume mounts for compose config and context
+if [ "$(pwd)" != '/' ]; then
+    VOLUMES="-v $(pwd):$(pwd)"
+fi
+if [ -n "$COMPOSE_FILE" ]; then
+    COMPOSE_OPTIONS="$COMPOSE_OPTIONS -e COMPOSE_FILE=$COMPOSE_FILE"
+    compose_dir=$(realpath $(dirname $COMPOSE_FILE))
+fi
+# TODO: also check --file argument
+if [ -n "$compose_dir" ]; then
+    VOLUMES="$VOLUMES -v $compose_dir:$compose_dir"
+fi
+if [ -n "$HOME" ]; then
+    VOLUMES="$VOLUMES -v $HOME:$HOME -v $HOME:/root" # mount $HOME in /root to share docker.config
+fi
+
+# Only allocate tty if we detect one
+if [ -t 1 ]; then
+    DOCKER_RUN_OPTIONS="-t"
+fi
+if [ -t 0 ]; then
+    DOCKER_RUN_OPTIONS="$DOCKER_RUN_OPTIONS -i"
+fi
+
+exec docker run --rm $DOCKER_RUN_OPTIONS $DOCKER_ADDR $COMPOSE_OPTIONS $VOLUMES -w "$(pwd)" $IMAGE "$@"


### PR DESCRIPTION
Installs compose as an image:

- uses docker daemon proxy settings to pull image
- can be configured to pull image from private registry
- docs updated in README